### PR TITLE
txt 파일 문서 추출 모듈 임시

### DIFF
--- a/src/main/java/com/fast/search/service/extract/Extract.java
+++ b/src/main/java/com/fast/search/service/extract/Extract.java
@@ -1,0 +1,7 @@
+package com.fast.search.service.extract;
+
+public interface Extract {
+
+    String extract();
+
+}

--- a/src/main/java/com/fast/search/service/extract/TxtExtract.java
+++ b/src/main/java/com/fast/search/service/extract/TxtExtract.java
@@ -1,0 +1,46 @@
+package com.fast.search.service.extract;
+
+import org.springframework.stereotype.Service;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+@Service
+public class TxtExtract implements Extract{
+    final String SOURCE_FILE_PATH = "C:/testdata/00003.txt";
+
+    @Override
+    public String extract() {
+
+        final int bufferMaxSize = 1024 * 1024;
+
+        Path sourceFilePath = Paths.get(SOURCE_FILE_PATH);
+
+        Charset charset = Charset.defaultCharset();
+        StringBuilder sb = new StringBuilder();
+
+        try (FileChannel sourceChannel = FileChannel.open(sourceFilePath, StandardOpenOption.READ);)
+        {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(bufferMaxSize);
+
+            while (sourceChannel.read(buffer) >= 0)
+            {
+                buffer.flip();
+
+                sb.append(charset.decode(buffer).toString());
+
+                buffer.clear();
+            }
+            System.out.println(sb.toString());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/fast/search/service/extract/TxtExtractTest.java
+++ b/src/test/java/com/fast/search/service/extract/TxtExtractTest.java
@@ -1,0 +1,20 @@
+package com.fast.search.service.extract;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class TxtExtractTest {
+
+    @Autowired
+    TxtExtract txtExtract;
+
+    @Test
+    void extract() {
+
+        txtExtract.extract();
+    }
+}


### PR DESCRIPTION
txt 파일 문서 추출 모듈을 임시로 만듦

현재 txt 파일을 읽고 sout으로 출력까지 가능하나 일단 폴더에서 목록을 읽고 추출 가능하도록 변경 예정
해당 이슈를 닫고 더 세부적으로 이슈 생성 후 추가 개발